### PR TITLE
Add helmet and secure cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Projeto completo de um sistema de Correio Elegante para festas e eventos, com en
 - **Backend:** Node.js, Express.js
 - **Comunicação Real-time:** Socket.IO
 - **Autenticação:** `cookie-session` para sessões de administrador.
+- **Segurança:** `helmet` para configurar cabeçalhos HTTP padrão.
 - **Frontend:** HTML5, CSS3, JavaScript (puro)
 - **Geração de QR Code:** `qrcode` (via CDN)
 - **Versionamento:** Git & GitHub

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cookie-session": "^2.1.0",
     "express": "^4.19.2",
     "express-useragent": "^1.0.15",
-    "socket.io": "^4.7.5"
+    "socket.io": "^4.7.5",
+    "helmet": "^7.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const cookieSession = require('cookie-session');
 const useragent = require('express-useragent');
+const helmet = require('helmet');
 
 const app = express();
 const server = http.createServer(app);
@@ -18,8 +19,12 @@ const SESSION_SECRET = process.env.SESSION_SECRET || 'mude-esta-chave-secreta-de
 app.use(cookieSession({
     name: 'session',
     keys: [SESSION_SECRET],
-    maxAge: 24 * 60 * 60 * 1000 // 24 horas
+    maxAge: 24 * 60 * 60 * 1000, // 24 horas
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production'
 }));
+
+app.use(helmet());
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add `helmet` dependency and middleware
- configure `cookieSession` with `httpOnly` and `secure` options
- document Helmet in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685305e63cb0832aa2e4783c78e4e436