### PR TITLE
Implement log retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,9 @@ Para que todos na festa possam acessar, o ideal é publicar o projeto na interne
 
 1. **Acesse o link do telão no projetor:** `https://SEU_LINK.onrender.com/display`
 2. **Coloque em tela cheia (F11)** e clique em "Iniciar Telão".
-3. O QR Code que aparecerá na tela já estará apontando para o seu site. Basta os convidados escanearem para começar a enviar as mensagens! 
+3. O QR Code que aparecerá na tela já estará apontando para o seu site. Basta os convidados escanearem para começar a enviar as mensagens!
+
+## 📜 Retenção de Mensagens
+
+O servidor guarda em memória apenas as últimas **100** mensagens (ou o valor definido na variável de ambiente `MAX_LOG_SIZE`).
+O histórico completo é salvo continuamente no arquivo `message_history.log` e pode ser acessado na página `/history`.

--- a/server.js
+++ b/server.js
@@ -29,6 +29,9 @@ app.use(useragent.express()); // Usar o middleware user-agent
 let messageQueue = [];
 let isDisplayBusy = false;
 let messageLog = [];
+// Mantém apenas as últimas N mensagens em memória para enviar aos clientes.
+// O histórico completo continua salvo em "message_history.log".
+const MAX_LOG_SIZE = parseInt(process.env.MAX_LOG_SIZE, 10) || 100;
 let connectedClients = {}; // Para rastrear clientes
 let blockedIps = new Set(); // Para armazenar IPs bloqueados
 let displayedMessagesLog = []; // Histórico para o carrossel
@@ -477,6 +480,10 @@ io.on('connection', (socket) => {
         };
         messageQueue.push(fullMessage);
         messageLog.push(fullMessage);
+        // Garante que apenas as últimas MAX_LOG_SIZE mensagens permaneçam em memória
+        while (messageLog.length > MAX_LOG_SIZE) {
+            messageLog.shift();
+        }
         appendToLogFile(fullMessage);
         
         // Notifica que uma NOVA mensagem chegou e atualiza a contagem


### PR DESCRIPTION
## Summary
- limit in-memory messageLog array to configurable size via `MAX_LOG_SIZE`
- document log retention policy in README

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685305e3a21c832ab5e15eb24ed96fd7