### PR TITLE
Adiciona log persistente em Gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,7 @@ Para que todos na festa possam acessar, o ideal é publicar o projeto na interne
 
 O servidor guarda em memória apenas as últimas **100** mensagens (ou o valor definido na variável de ambiente `MAX_LOG_SIZE`).
 O histórico completo é salvo continuamente no arquivo `message_history.log` e pode ser acessado na página `/history`.
+
+### Log Persistente em Nuvem
+
+Para evitar a perda do histórico em provedores que não mantêm arquivos locais (como o Render), é possível configurar um Gist do GitHub para armazenar as mensagens. Basta definir as variáveis de ambiente `GITHUB_TOKEN`, `GIST_ID` e opcionalmente `GIST_FILENAME`. Quando configurado, cada nova mensagem é adicionada também ao Gist, mantendo um backup permanente.

--- a/remoteLogger.js
+++ b/remoteLogger.js
@@ -1,0 +1,83 @@
+const https = require('https');
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GIST_ID = process.env.GIST_ID;
+const GIST_FILENAME = process.env.GIST_FILENAME || 'message_history.log';
+
+async function appendToGist(content) {
+  if (!GITHUB_TOKEN || !GIST_ID) {
+    return;
+  }
+  try {
+    const existing = await fetchGist();
+    const file = existing.files && existing.files[GIST_FILENAME];
+    const newContent = (file ? file.content : '') + content;
+    await updateGist(newContent);
+  } catch (err) {
+    console.error('Erro ao atualizar gist:', err);
+  }
+}
+
+function fetchGist() {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.github.com',
+      path: `/gists/${GIST_ID}`,
+      method: 'GET',
+      headers: {
+        'User-Agent': 'correio-elegante',
+        'Authorization': `token ${GITHUB_TOKEN}`,
+        'Accept': 'application/vnd.github.v3+json'
+      }
+    };
+
+    https
+      .get(options, res => {
+        let body = '';
+        res.on('data', chunk => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(body));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+function updateGist(content) {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify({
+      files: {
+        [GIST_FILENAME]: { content }
+      }
+    });
+
+    const options = {
+      hostname: 'api.github.com',
+      path: `/gists/${GIST_ID}`,
+      method: 'PATCH',
+      headers: {
+        'User-Agent': 'correio-elegante',
+        'Authorization': `token ${GITHUB_TOKEN}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data)
+      }
+    };
+
+    const req = https.request(options, res => {
+      res.on('data', () => {});
+      res.on('end', resolve);
+    });
+    req.on('error', reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+module.exports = { appendToGist };

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const path = require('path');
 const cookieSession = require('cookie-session');
 const useragent = require('express-useragent');
 const helmet = require('helmet');
+const { appendToGist } = require('./remoteLogger');
 
 const app = express();
 app.set('trust proxy', 1); // Confia no proxy reverso (essencial para o Render)
@@ -269,6 +270,13 @@ const appendToLogFile = (message) => {
             console.error('Erro ao escrever no arquivo de log:', err);
         }
     });
+    // Salva o log remotamente, se configurado
+    // Tenta salvar no Gist se as variáveis de ambiente estiverem definidas
+    if (appendToGist) {
+        appendToGist(logEntry).catch(err => {
+            console.error('Falha ao registrar log remoto:', err.message);
+        });
+    }
 };
 
 // Função para ler categorias e mensagens do arquivo


### PR DESCRIPTION
## Resumo
- registra logs também em um Gist do GitHub se configurado
- documenta as variáveis de ambiente para log em nuvem

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a082d5a7c832abe844b3b99e8a393