### PR TITLE
Remove unused display modes

### DIFF
--- a/private/admin.html
+++ b/private/admin.html
@@ -20,14 +20,6 @@
             <a href="/logout" class="logout-btn">🚪 Sair</a>
         </nav>
         
-        <section class="admin-section" id="display-mode-section">
-            <h2>Modo de Exibição do Telão</h2>
-            <div class="form-group">
-                <label><input type="radio" name="displayMode" value="default"> Padrão</label>
-                <label><input type="radio" name="displayMode" value="carousel"> Carrossel</label>
-                <label><input type="radio" name="displayMode" value="ticker"> Letreiro</label>
-            </div>
-        </section>
 
         <section class="admin-section" id="category-management-section">
             <h2>Gerenciar Categorias</h2>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -495,86 +495,36 @@ body.display-page {
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
+}
+.display-page .message-card .message-text::before,
+.display-page .message-card .message-text::after {
+    font-family: 'Lilita One', cursive;
+    font-size: 6rem;
+    color: var(--primary-color);
+    position: absolute;
+    line-height: 0.5;
+}
+.display-page .message-card .message-text::before {
+    content: "\201C"; /* left double quote */
+    left: -40px;
+    top: -20px;
+}
+.display-page .message-card .message-text::after {
+    content: "\201D"; /* right double quote */
+    right: -40px;
+    bottom: -20px;
 }
 
 .display-page .message-card .timestamp {
     font-family: 'Poppins', sans-serif;
-    font-size: 1.2rem;
-    color: #999;
+    font-size: clamp(1rem, 2.5vw, 1.5rem);
+    color: #666;
     text-align: right;
-    margin-top: 15px;
-    font-weight: 400;
+    margin-top: 10px;
+    font-style: italic;
 }
 
-.display-page #carousel-mode-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-}
-.display-page #carousel-slide {
-    flex-grow: 1;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.display-page .carousel-nav {
-    background: none;
-    border: none;
-    color: var(--primary-color);
-    font-size: 4rem;
-    cursor: pointer;
-    transition: transform 0.2s, color 0.2s;
-    padding: 20px;
-    width: auto;
-}
-.display-page .carousel-nav:hover {
-    color: #8e44ad;
-    transform: scale(1.1);
-}
-.display-page .carousel-speak-btn {
-    background: var(--accent-color);
-    color: var(--primary-color);
-    border: none;
-    border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    font-size: 1.5rem;
-    cursor: pointer;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-    transition: all 0.2s ease;
-    padding: 0;
-    margin-top: 15px;
-}
-.display-page .carousel-speak-btn:hover { transform: scale(1.1); }
-.display-page .carousel-speak-btn.speaking { animation: pulse 1s; }
-
-.display-page #ticker-mode-container {
-    overflow: hidden;
-    width: 100%;
-}
-.display-page .ticker-wrap {
-    width: 100%;
-    display: flex;
-    align-items: center;
-}
-.display-page #ticker-content {
-    font-family: 'Lilita One', cursive;
-    font-size: 5rem;
-    color: #fff;
-    white-space: nowrap;
-    display: inline-block;
-    padding-left: 100%;
-    text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.8);
-}
-.display-page #ticker-content.animate {
-    animation: ticker-animation 60s linear infinite;
-}
-@keyframes ticker-animation {
-    from { transform: translateX(100%); }
-    to { transform: translateX(-100%); }
-}
 
 #queue-counter {
     position: fixed;
@@ -675,15 +625,6 @@ body.display-page {
     }
     .display-page .message-card .message-text {
         font-size: clamp(1.2rem, 8vw, 2.2rem);
-    }
-    .display-page .carousel-nav {
-        font-size: 2.5rem;
-        padding: 10px;
-    }
-    .display-page .carousel-speak-btn {
-        width: 45px;
-        height: 45px;
-        font-size: 1.2rem;
     }
 }
 

--- a/public/display.html
+++ b/public/display.html
@@ -55,26 +55,9 @@
                         <div id="message-display">
                             <div class="message-card">
                                 <p class="recipient">Para: <span id="display-recipient"></span></p>
-                                <p class="message-text">"<span id="display-message"></span>"</p>
+                                <p class="message-text"><span id="display-message"></span></p>
                                 <p class="sender">De: <span id="display-sender"></span></p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- MODO CARROSSEL -->
-                    <div id="carousel-mode-container" class="mode-container hidden">
-                        <button id="carousel-prev" class="carousel-nav" aria-label="Mensagem Anterior"><i class="fas fa-chevron-left"></i></button>
-                        <div id="carousel-slide">
-                            <!-- O conteúdo da mensagem do carrossel será inserido aqui -->
-                        </div>
-                        <button id="carousel-next" class="carousel-nav" aria-label="Próxima Mensagem"><i class="fas fa-chevron-right"></i></button>
-                    </div>
-
-                    <!-- MODO LETREIRO -->
-                    <div id="ticker-mode-container" class="mode-container hidden">
-                        <div class="ticker-wrap">
-                            <div id="ticker-content" class="ticker-item">
-                                <!-- O conteúdo do letreiro será inserido aqui -->
+                                <p class="timestamp" id="display-timestamp"></p>
                             </div>
                         </div>
                     </div>

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -9,7 +9,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveChangesBtn = document.getElementById('btn-save-messages');
     const categoriesListContainer = document.getElementById('categories-list');
     const addCategoryBtn = document.getElementById('btn-add-category');
-    const displayModeRadios = document.querySelectorAll('input[name="displayMode"]');
 
     let categories = [];
     let messages = [];
@@ -95,26 +94,7 @@ document.addEventListener('DOMContentLoaded', () => {
     socket.emit('getConfig');
 
     // --- Lógica do Modo de Exibição ---
-    socket.on('initialState', (state) => {
-        const currentMode = state.displayMode;
-        const radioToCheck = document.querySelector(`input[name="displayMode"][value="${currentMode}"]`);
-        if (radioToCheck) {
-            radioToCheck.checked = true;
-        }
-    });
-
-    socket.on('modeUpdate', (newMode) => {
-        const radioToCheck = document.querySelector(`input[name="displayMode"][value="${newMode}"]`);
-        if (radioToCheck) {
-            radioToCheck.checked = true;
-        }
-    });
-
-    displayModeRadios.forEach(radio => {
-        radio.addEventListener('change', (event) => {
-            socket.emit('setDisplayMode', event.target.value);
-        });
-    });
+    // Modos alternativos removidos - apenas o padrão permanece
     // --- Fim da Lógica ---
 
     // Adiciona um novo campo de mensagem

--- a/public/js/display.js
+++ b/public/js/display.js
@@ -19,21 +19,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const incentivePhraseEl = document.getElementById('incentive-phrase');
     const totalCountEl = document.getElementById('total-count');
 
-    // --- Elementos dos Modos (Default, Carousel, Ticker) ---
-    const modeContainers = document.querySelectorAll('.mode-container');
+    // --- Elementos do Modo Padrão ---
     const defaultRecipientSpan = document.getElementById('display-recipient');
     const defaultMessageSpan = document.getElementById('display-message');
     const defaultSenderSpan = document.getElementById('display-sender');
-    const carouselSlide = document.getElementById('carousel-slide');
-    const carouselPrevBtn = document.getElementById('carousel-prev');
-    const carouselNextBtn = document.getElementById('carousel-next');
-    const tickerContent = document.getElementById('ticker-content');
+    const defaultTimestamp = document.getElementById('display-timestamp');
 
     // --- Estado do Display ---
-    let currentMode = 'default';
     let displayedHistory = [];
-    let carouselIndex = -1;
-    let carouselTimeout;
     let currentMessageTimeout;
     let minDisplayTimeout; // Novo temporizador para o tempo mínimo
     let messageStartTime = null;
@@ -95,7 +88,6 @@ document.addEventListener('DOMContentLoaded', () => {
             clearInterval(historyAnimationInterval);
             historyAnimationInterval = null;
         }
-        if (currentMode === 'ticker') tickerContent.classList.remove('animate');
 
         if (state === 'waiting') {
             waitingScreen.classList.remove('hidden');
@@ -154,69 +146,18 @@ document.addEventListener('DOMContentLoaded', () => {
         defaultMessageSpan.textContent = msg.message;
         defaultSenderSpan.textContent = msg.sender;
 
-        // Adiciona a hora formatada
+        // Atualiza a hora formatada
         const time = new Date(msg.timestamp).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
-        const timeEl = document.createElement('p');
-        timeEl.className = 'timestamp';
-        timeEl.textContent = `Enviado às ${time}`;
-        // Limpa timestamp antigo e adiciona o novo
-        const oldTime = defaultMessageSpan.parentNode.querySelector('.timestamp');
-        if(oldTime) oldTime.remove();
-        defaultMessageSpan.parentNode.appendChild(timeEl);
+        defaultTimestamp.textContent = `Enviado às ${time}`;
 
         adjustFontSize(defaultMessageSpan, msg.message);
     };
 
-    const renderCarousel = (index) => {
-        if (index < 0 || index >= displayedHistory.length) return;
-        carouselIndex = index;
-        const msg = displayedHistory[index];
-        const time = new Date(msg.timestamp).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
-        carouselSlide.innerHTML = `
-            <div class="message-card">
-                <p class="recipient">Para: <span>${msg.recipient}</span></p>
-                <p class="message-text">"<span>${msg.message}</span>"</p>
-                <p class="sender">De: <span>${msg.sender}</span></p>
-                <p class="timestamp">Enviado às ${time}</p>
-                <button class="carousel-speak-btn" aria-label="Ler mensagem"><i class="fas fa-volume-up"></i></button>
-            </div>
-        `;
-        adjustFontSize(carouselSlide.querySelector('.message-text > span'), msg.message);
-        carouselPrevBtn.style.visibility = (index > 0) ? 'visible' : 'hidden';
-        carouselNextBtn.style.visibility = (index < displayedHistory.length - 1) ? 'visible' : 'hidden';
-    };
-
-    const renderTicker = (msg) => {
-        tickerContent.innerHTML = `Para: <strong>${msg.recipient}</strong> — "${msg.message}" — De: <strong>${msg.sender}</strong>`;
-        const speedFactor = 0.08; // segundos por caracter
-        const duration = tickerContent.textContent.length * speedFactor;
-        tickerContent.style.animationDuration = `${Math.max(10, duration)}s`;
-        tickerContent.classList.add('animate');
-    };
 
     // --- Controle de Exibição ---
-    const switchMode = (newMode) => {
-        currentMode = newMode;
-        modeContainers.forEach(c => c.classList.add('hidden'));
-        const activeContainer = document.getElementById(`${newMode}-mode-container`);
-        if (activeContainer) activeContainer.classList.remove('hidden');
-        console.log(`Modo alterado para: ${newMode}`);
-    };
-
     const startDisplay = (msg, duration) => {
         setScreenState('message');
-        switch (currentMode) {
-            case 'default':
-                renderDefault(msg);
-                break;
-            case 'carousel':
-                renderCarousel(displayedHistory.length - 1);
-                clearTimeout(carouselTimeout); // Para o timer de auto-avanço se uma nova msg chegar
-                break;
-            case 'ticker':
-                renderTicker(msg);
-                break;
-        }
+        renderDefault(msg);
         const fullText = `Correio Elegante para ${msg.recipient}. A mensagem é: ${msg.message}. Enviado por: ${msg.sender}.`;
         speakMessage(fullText);
         
@@ -264,7 +205,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Listeners de Socket ---
     socket.on('initialState', state => {
         console.log("Estado inicial recebido:", state);
-        switchMode(state.displayMode);
         displayedHistory = state.displayedHistory || [];
         totalMessages = state.totalMessages || 0; // Garante que seja um número
         updateTotalMessagesDisplay();
@@ -276,8 +216,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const remainingTime = MAX_DISPLAY_TIME - elapsedTime;
             
             if (remainingTime > 1000) { // Se resta mais de 1 segundo
-                // Define o histórico para que o carrossel funcione corretamente
-                displayedHistory = state.displayedHistory; 
+                displayedHistory = state.displayedHistory;
                 startDisplay(state.currentMessage, remainingTime);
             } else {
                 // Se o tempo já expirou, notifica o servidor e vai para a espera
@@ -289,7 +228,6 @@ document.addEventListener('DOMContentLoaded', () => {
             setScreenState('waiting');
         }
     });
-    socket.on('modeUpdate', newMode => switchMode(newMode));
     socket.on('displayMessage', data => {
         log(`Recebida nova mensagem do servidor (ID: ${data.message.id}).`);
         totalMessages = data.totalMessages || 0;
@@ -334,27 +272,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- Listeners de Eventos ---
-    carouselPrevBtn.addEventListener('click', () => {
-        clearTimeout(carouselTimeout);
-        if (carouselIndex > 0) renderCarousel(carouselIndex - 1);
-    });
-    carouselNextBtn.addEventListener('click', () => {
-        clearTimeout(carouselTimeout);
-        if (carouselIndex < displayedHistory.length - 1) renderCarousel(carouselIndex + 1);
-    });
-    carouselSlide.addEventListener('click', (event) => {
-        const speakBtn = event.target.closest('.carousel-speak-btn');
-        if (speakBtn) {
-            clearTimeout(carouselTimeout);
-            const msg = displayedHistory[carouselIndex];
-            const text = `Para ${msg.recipient}, ${msg.message}, de ${msg.sender}.`;
-            speakMessage(text);
-            
-            // Feedback visual no botão
-            speakBtn.classList.add('speaking');
-            setTimeout(() => speakBtn.classList.remove('speaking'), 1000);
-        }
-    });
 
     // --- Função para atualizar display de mensagens com singular/plural correto ---
     const updateTotalMessagesDisplay = () => {

--- a/server.js
+++ b/server.js
@@ -59,8 +59,8 @@ let messageLog = [];
 const MAX_LOG_SIZE = parseInt(process.env.MAX_LOG_SIZE, 10) || 100;
 let connectedClients = {}; // Para rastrear clientes
 let blockedIps = new Set(); // Para armazenar IPs bloqueados
-let displayedMessagesLog = []; // Histórico para o carrossel
-let currentDisplayMode = 'default'; // Modos: 'default', 'carousel', 'ticker'
+let displayedMessagesLog = []; // Histórico de mensagens exibidas
+let currentDisplayMode = 'default';
 let currentMessage = null; // Rastreia a mensagem atualmente em exibição
 let idleLoopTimeout = null; // Novo: controla o ciclo de ociosidade
 
@@ -531,8 +531,7 @@ io.on('connection', (socket) => {
 
     // Envia o modo de exibição atual para o cliente que acabou de se conectar
     // Útil principalmente para admin e display
-    socket.emit('initialState', { 
-        displayMode: currentDisplayMode,
+    socket.emit('initialState', {
         displayedHistory: displayedMessagesLog,
         totalMessages: messageLog ? messageLog.length : 0,
         isBusy: isDisplayBusy,
@@ -590,8 +589,7 @@ io.on('connection', (socket) => {
             log('Cliente de telão se conectou e foi adicionado à sala.');
             
             // Envia o estado atual completo para o novo cliente de telão
-            socket.emit('initialState', { 
-                displayMode: currentDisplayMode,
+            socket.emit('initialState', {
                 displayedHistory: displayedMessagesLog,
                 totalMessages: messageLog ? messageLog.length : 0, // Garante que seja um número
                 isBusy: isDisplayBusy,
@@ -675,15 +673,6 @@ io.on('connection', (socket) => {
         }
     });
 
-    // Novo evento para definir o modo de exibição
-    socket.on('setDisplayMode', (mode) => {
-        if (['default', 'carousel', 'ticker'].includes(mode)) {
-            currentDisplayMode = mode;
-            console.log(`Modo de exibição alterado para: ${mode}`);
-            // Envia a atualização para todos, incluindo os painéis de admin
-            io.emit('modeUpdate', currentDisplayMode);
-        }
-    });
 
     // Novo evento para bloquear um IP
     socket.on('blockIp', (ipToBlock) => {


### PR DESCRIPTION
## Summary
- drop carousel and ticker modes leaving only the default display
- clean admin panel and scripts for removed modes
- tweak quote and timestamp styling in default mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a2683719c832ab4e50db338d0df00