### PR TITLE
Remove unused display modes

### DIFF
--- a/private/admin.html
+++ b/private/admin.html
@@ -20,14 +20,6 @@
             <a href="/logout" class="logout-btn">🚪 Sair</a>
         </nav>
         
-        <section class="admin-section" id="display-mode-section">
-            <h2>Modo de Exibição do Telão</h2>
-            <div class="form-group">
-                <label><input type="radio" name="displayMode" value="default"> Padrão</label>
-                <label><input type="radio" name="displayMode" value="carousel"> Carrossel</label>
-                <label><input type="radio" name="displayMode" value="ticker"> Letreiro</label>
-            </div>
-        </section>
 
         <section class="admin-section" id="category-management-section">
             <h2>Gerenciar Categorias</h2>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -495,86 +495,29 @@ body.display-page {
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
+    padding: 0 2rem;
 }
+.display-page .message-card .message-text::before,
+.display-page .message-card .message-text::after {
+    font-family: 'Lilita One', cursive;
+    font-size: 5rem;
+    color: var(--primary-color);
+    position: absolute;
+    top: -20px;
+}
+.display-page .message-card .message-text::before { content: '“'; left: 0; }
+.display-page .message-card .message-text::after { content: '”'; right: 0; }
 
 .display-page .message-card .timestamp {
     font-family: 'Poppins', sans-serif;
     font-size: 1.2rem;
-    color: #999;
+    color: #555;
     text-align: right;
-    margin-top: 15px;
+    margin-top: 10px;
     font-weight: 400;
 }
 
-.display-page #carousel-mode-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 20px;
-}
-.display-page #carousel-slide {
-    flex-grow: 1;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.display-page .carousel-nav {
-    background: none;
-    border: none;
-    color: var(--primary-color);
-    font-size: 4rem;
-    cursor: pointer;
-    transition: transform 0.2s, color 0.2s;
-    padding: 20px;
-    width: auto;
-}
-.display-page .carousel-nav:hover {
-    color: #8e44ad;
-    transform: scale(1.1);
-}
-.display-page .carousel-speak-btn {
-    background: var(--accent-color);
-    color: var(--primary-color);
-    border: none;
-    border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    font-size: 1.5rem;
-    cursor: pointer;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-    transition: all 0.2s ease;
-    padding: 0;
-    margin-top: 15px;
-}
-.display-page .carousel-speak-btn:hover { transform: scale(1.1); }
-.display-page .carousel-speak-btn.speaking { animation: pulse 1s; }
-
-.display-page #ticker-mode-container {
-    overflow: hidden;
-    width: 100%;
-}
-.display-page .ticker-wrap {
-    width: 100%;
-    display: flex;
-    align-items: center;
-}
-.display-page #ticker-content {
-    font-family: 'Lilita One', cursive;
-    font-size: 5rem;
-    color: #fff;
-    white-space: nowrap;
-    display: inline-block;
-    padding-left: 100%;
-    text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.8);
-}
-.display-page #ticker-content.animate {
-    animation: ticker-animation 60s linear infinite;
-}
-@keyframes ticker-animation {
-    from { transform: translateX(100%); }
-    to { transform: translateX(-100%); }
-}
 
 #queue-counter {
     position: fixed;
@@ -675,15 +618,6 @@ body.display-page {
     }
     .display-page .message-card .message-text {
         font-size: clamp(1.2rem, 8vw, 2.2rem);
-    }
-    .display-page .carousel-nav {
-        font-size: 2.5rem;
-        padding: 10px;
-    }
-    .display-page .carousel-speak-btn {
-        width: 45px;
-        height: 45px;
-        font-size: 1.2rem;
     }
 }
 

--- a/public/display.html
+++ b/public/display.html
@@ -51,30 +51,12 @@
             <div id="content-panel">
                 <div class="display-wrapper">
                     <!-- MODO PADRÃO -->
-                    <div id="default-mode-container" class="mode-container hidden">
+                    <div id="default-mode-container" class="mode-container">
                         <div id="message-display">
                             <div class="message-card">
                                 <p class="recipient">Para: <span id="display-recipient"></span></p>
-                                <p class="message-text">"<span id="display-message"></span>"</p>
+                                <p class="message-text"><span id="display-message"></span></p>
                                 <p class="sender">De: <span id="display-sender"></span></p>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- MODO CARROSSEL -->
-                    <div id="carousel-mode-container" class="mode-container hidden">
-                        <button id="carousel-prev" class="carousel-nav" aria-label="Mensagem Anterior"><i class="fas fa-chevron-left"></i></button>
-                        <div id="carousel-slide">
-                            <!-- O conteúdo da mensagem do carrossel será inserido aqui -->
-                        </div>
-                        <button id="carousel-next" class="carousel-nav" aria-label="Próxima Mensagem"><i class="fas fa-chevron-right"></i></button>
-                    </div>
-
-                    <!-- MODO LETREIRO -->
-                    <div id="ticker-mode-container" class="mode-container hidden">
-                        <div class="ticker-wrap">
-                            <div id="ticker-content" class="ticker-item">
-                                <!-- O conteúdo do letreiro será inserido aqui -->
                             </div>
                         </div>
                     </div>

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -9,7 +9,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveChangesBtn = document.getElementById('btn-save-messages');
     const categoriesListContainer = document.getElementById('categories-list');
     const addCategoryBtn = document.getElementById('btn-add-category');
-    const displayModeRadios = document.querySelectorAll('input[name="displayMode"]');
 
     let categories = [];
     let messages = [];
@@ -94,28 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     socket.emit('getConfig');
 
-    // --- Lógica do Modo de Exibição ---
-    socket.on('initialState', (state) => {
-        const currentMode = state.displayMode;
-        const radioToCheck = document.querySelector(`input[name="displayMode"][value="${currentMode}"]`);
-        if (radioToCheck) {
-            radioToCheck.checked = true;
-        }
-    });
-
-    socket.on('modeUpdate', (newMode) => {
-        const radioToCheck = document.querySelector(`input[name="displayMode"][value="${newMode}"]`);
-        if (radioToCheck) {
-            radioToCheck.checked = true;
-        }
-    });
-
-    displayModeRadios.forEach(radio => {
-        radio.addEventListener('change', (event) => {
-            socket.emit('setDisplayMode', event.target.value);
-        });
-    });
-    // --- Fim da Lógica ---
 
     // Adiciona um novo campo de mensagem
     addMessageBtn.addEventListener('click', () => {

--- a/server.js
+++ b/server.js
@@ -60,7 +60,6 @@ const MAX_LOG_SIZE = parseInt(process.env.MAX_LOG_SIZE, 10) || 100;
 let connectedClients = {}; // Para rastrear clientes
 let blockedIps = new Set(); // Para armazenar IPs bloqueados
 let displayedMessagesLog = []; // Histórico para o carrossel
-let currentDisplayMode = 'default'; // Modos: 'default', 'carousel', 'ticker'
 let currentMessage = null; // Rastreia a mensagem atualmente em exibição
 let idleLoopTimeout = null; // Novo: controla o ciclo de ociosidade
 
@@ -531,8 +530,7 @@ io.on('connection', (socket) => {
 
     // Envia o modo de exibição atual para o cliente que acabou de se conectar
     // Útil principalmente para admin e display
-    socket.emit('initialState', { 
-        displayMode: currentDisplayMode,
+    socket.emit('initialState', {
         displayedHistory: displayedMessagesLog,
         totalMessages: messageLog ? messageLog.length : 0,
         isBusy: isDisplayBusy,
@@ -590,8 +588,7 @@ io.on('connection', (socket) => {
             log('Cliente de telão se conectou e foi adicionado à sala.');
             
             // Envia o estado atual completo para o novo cliente de telão
-            socket.emit('initialState', { 
-                displayMode: currentDisplayMode,
+            socket.emit('initialState', {
                 displayedHistory: displayedMessagesLog,
                 totalMessages: messageLog ? messageLog.length : 0, // Garante que seja um número
                 isBusy: isDisplayBusy,
@@ -675,15 +672,6 @@ io.on('connection', (socket) => {
         }
     });
 
-    // Novo evento para definir o modo de exibição
-    socket.on('setDisplayMode', (mode) => {
-        if (['default', 'carousel', 'ticker'].includes(mode)) {
-            currentDisplayMode = mode;
-            console.log(`Modo de exibição alterado para: ${mode}`);
-            // Envia a atualização para todos, incluindo os painéis de admin
-            io.emit('modeUpdate', currentDisplayMode);
-        }
-    });
 
     // Novo evento para bloquear um IP
     socket.on('blockIp', (ipToBlock) => {


### PR DESCRIPTION
## Summary
- drop carousel and ticker modes from telão and admin
- simplify layout for the default mode
- style bigger quotes around the message and tweak timestamp color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a2683719c832ab4e50db338d0df00