### PR TITLE
Improve admin page layout

### DIFF
--- a/private/admin.html
+++ b/private/admin.html
@@ -6,7 +6,7 @@
     <title>Admin - Correio Elegante</title>
     <link rel="stylesheet" href="/css/style.css">
 </head>
-<body>
+<body class="admin-page">
     <div class="container">
         <header>
             <h1><img src="/images/logo.png" alt="Big Arraiá Ultra Bão" class="inline-logo"> Administração</h1>

--- a/private/clients.html
+++ b/private/clients.html
@@ -99,7 +99,7 @@
         }
     </style>
 </head>
-<body>
+<body class="admin-page">
     <div class="container">
         <header>
             <h1><img src="/images/logo.png" alt="Big Arraiá Ultra Bão" class="inline-logo"> Monitor de Clientes</h1>

--- a/private/history.html
+++ b/private/history.html
@@ -38,7 +38,7 @@
         }
     </style>
 </head>
-<body>
+<body class="admin-page">
     <div class="container">
         <header>
             <h1><img src="/images/logo.png" alt="Big Arraiá Ultra Bão" class="inline-logo"> Histórico de Mensagens</h1>

--- a/private/stats.html
+++ b/private/stats.html
@@ -56,7 +56,7 @@
         }
     </style>
 </head>
-<body>
+<body class="admin-page">
     <div class="container">
         <header>
             <h1><img src="/images/logo.png" alt="Big Arraiá Ultra Bão" class="inline-logo"> Estatísticas</h1>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -63,6 +63,13 @@ body {
     min-width: 0;
 }
 
+body.admin-page {
+    display: block;
+}
+body.admin-page .container {
+    max-width: 100%;
+}
+
 header {
     margin-bottom: 20px;
     display: flex;
@@ -215,15 +222,36 @@ button:hover {
 }
 .message-item-admin {
     display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 10px;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 15px;
+    background-color: #f9f9f9;
+    padding: 10px;
+    border-radius: 8px;
 }
 .message-item-admin textarea {
-    flex-grow: 1;
-    min-height: 40px;
+    width: 100%;
+    min-height: 80px;
     height: auto;
     resize: vertical;
+}
+.message-controls {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+.btn-move {
+    background: #6c63ff;
+    color: white;
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 8px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+.btn-move:hover {
+    background: #594ee3;
 }
 .btn-delete {
     background: #e74c3c;
@@ -257,6 +285,10 @@ button:hover {
 }
 .category-item input {
     flex-grow: 1;
+}
+.category-controls {
+    display: flex;
+    gap: 8px;
 }
 
 /* ==========================================================================

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -30,6 +30,9 @@ document.addEventListener('DOMContentLoaded', () => {
         textarea.placeholder = "Digite a nova mensagem aqui...";
         textarea.addEventListener('input', () => autoGrow(textarea));
 
+        const controls = document.createElement('div');
+        controls.className = 'message-controls';
+
         const select = document.createElement('select');
         categories.forEach(cat => {
             const opt = document.createElement('option');
@@ -39,6 +42,28 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         select.value = msg.category || categories[0] || '';
 
+        const upBtn = document.createElement('button');
+        upBtn.className = 'btn-move';
+        upBtn.innerHTML = '⬆️';
+        upBtn.type = 'button';
+        upBtn.addEventListener('click', () => {
+            const prev = messageItem.previousElementSibling;
+            if (prev) {
+                messageItem.parentNode.insertBefore(messageItem, prev);
+            }
+        });
+
+        const downBtn = document.createElement('button');
+        downBtn.className = 'btn-move';
+        downBtn.innerHTML = '⬇️';
+        downBtn.type = 'button';
+        downBtn.addEventListener('click', () => {
+            const next = messageItem.nextElementSibling;
+            if (next) {
+                messageItem.parentNode.insertBefore(next, messageItem);
+            }
+        });
+
         const deleteBtn = document.createElement('button');
         deleteBtn.className = 'btn-delete';
         deleteBtn.innerHTML = '🗑️';
@@ -47,12 +72,16 @@ document.addEventListener('DOMContentLoaded', () => {
             messageItem.remove();
         });
 
+        controls.appendChild(select);
+        controls.appendChild(upBtn);
+        controls.appendChild(downBtn);
+        controls.appendChild(deleteBtn);
+
         messageItem.appendChild(textarea);
-        messageItem.appendChild(select);
-        messageItem.appendChild(deleteBtn);
-        
+        messageItem.appendChild(controls);
+
         setTimeout(() => autoGrow(textarea), 0);
-        
+
         return messageItem;
     };
 
@@ -66,22 +95,58 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
     
+    const createCategoryItem = (cat = '') => {
+        const div = document.createElement('div');
+        div.className = 'category-item';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = cat;
+
+        const controls = document.createElement('div');
+        controls.className = 'category-controls';
+
+        const upBtn = document.createElement('button');
+        upBtn.className = 'btn-move';
+        upBtn.innerHTML = '⬆️';
+        upBtn.type = 'button';
+        upBtn.addEventListener('click', () => {
+            const prev = div.previousElementSibling;
+            if (prev) {
+                div.parentNode.insertBefore(div, prev);
+            }
+        });
+
+        const downBtn = document.createElement('button');
+        downBtn.className = 'btn-move';
+        downBtn.innerHTML = '⬇️';
+        downBtn.type = 'button';
+        downBtn.addEventListener('click', () => {
+            const next = div.nextElementSibling;
+            if (next) {
+                div.parentNode.insertBefore(next, div);
+            }
+        });
+
+        const del = document.createElement('button');
+        del.className = 'btn-delete';
+        del.innerHTML = '🗑️';
+        del.type = 'button';
+        del.addEventListener('click', () => div.remove());
+
+        controls.appendChild(upBtn);
+        controls.appendChild(downBtn);
+        controls.appendChild(del);
+
+        div.appendChild(input);
+        div.appendChild(controls);
+        return div;
+    };
+
     const renderCategories = () => {
         categoriesListContainer.innerHTML = '';
         categories.forEach(cat => {
-            const div = document.createElement('div');
-            div.className = 'category-item';
-            const input = document.createElement('input');
-            input.type = 'text';
-            input.value = cat;
-            const del = document.createElement('button');
-            del.className = 'btn-delete';
-            del.innerHTML = '🗑️';
-            del.type = 'button';
-            del.addEventListener('click', () => div.remove());
-            div.appendChild(input);
-            div.appendChild(del);
-            categoriesListContainer.appendChild(div);
+            const item = createCategoryItem(cat);
+            categoriesListContainer.appendChild(item);
         });
     };
 
@@ -125,20 +190,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     addCategoryBtn.addEventListener('click', () => {
-        const div = document.createElement('div');
-        div.className = 'category-item';
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.placeholder = 'Nova categoria';
-        const del = document.createElement('button');
-        del.className = 'btn-delete';
-        del.innerHTML = '🗑️';
-        del.type = 'button';
-        del.addEventListener('click', () => div.remove());
-        div.appendChild(input);
-        div.appendChild(del);
+        const div = createCategoryItem('');
+        div.querySelector('input').placeholder = 'Nova categoria';
         categoriesListContainer.appendChild(div);
-        input.focus();
+        div.querySelector('input').focus();
     });
 
     // Salva as alterações


### PR DESCRIPTION
## Summary
- allow admin pages to use full width with `.admin-page`
- rearrange admin message items vertically
- add up/down ordering controls for messages and categories
- widen admin container on all admin screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a29089114832aa1872af65d2b9172