### PR TITLE
Hotfix: corrige erro de sintaxe que impedia o servidor de iniciar

### DIFF
--- a/remoteLogger.js
+++ b/remoteLogger.js
@@ -47,14 +47,18 @@ async function flushBuffer(additionalContent = '') {
     flushTimeout = null;
   }
   
+  // Prepara conteúdo do buffer fora do try para ficar acessível no catch
+  let bufferContent = '';
+  if (messageBuffer.length > 0) {
+    bufferContent = messageBuffer.join('\n') + '\n';
+  }
+  
   try {
     const existing = await fetchGist();
     const file = existing.files && existing.files[GIST_FILENAME];
     
-    // Prepara conteúdo do buffer
-    let bufferContent = '';
-    if (messageBuffer.length > 0) {
-      bufferContent = messageBuffer.join('\n') + '\n';
+    // Limpa o buffer apenas se vamos tentar enviar
+    if (bufferContent) {
       messageBuffer = []; // Limpa o buffer
     }
     
@@ -73,8 +77,8 @@ async function flushBuffer(additionalContent = '') {
 process.on('SIGTERM', async () => {
   console.log('Enviando buffer antes de encerrar...');
   await flushBuffer('\n=== SERVIDOR ENCERRADO ===\n' + 
-    `Data/Hora: ${new Date().toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' })}\n` +
-    `========================\n\n');
+    'Data/Hora: ' + new Date().toLocaleString('pt-BR', { timeZone: 'America/Sao_Paulo' }) + '\n' +
+    '========================\n\n');
 });
 
 function fetchGist() {
@@ -139,4 +143,4 @@ function updateGist(content) {
   });
 }
 
-module.exports = { appendToGist };
+module.exports = { appendToGist }; 


### PR DESCRIPTION
##  Correção Urgente

O servidor não estava iniciando no Render devido a um erro de sintaxe no arquivo remoteLogger.js.

##  Problema
- Erro: SyntaxError na linha 88 do remoteLogger.js
- Template literals com problemas de parsing
- Servidor não conseguia iniciar no Render

##  Solução
- Convertido template literals problemáticos para concatenação de strings
- Arquivo reescrito para evitar problemas de encoding
- Testado localmente e funcionando corretamente

##  Urgência
Esta é uma correção crítica pois o servidor está fora do ar em produção.

Por favor, fazer merge imediatamente!