### PR TITLE
Enhance memory mode display

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -928,7 +928,7 @@ body.display-page {
 /* ==========================================================================
    Antigos Estilos de Memórias (Removidos/Adaptados)
    ========================================================================== */
-#history-content, #message-bubbles-container, .message-bubble, #history-header {
+#history-content, #history-header {
     display: none;
 }
 
@@ -960,5 +960,78 @@ body.display-page {
     height: 70px;
     max-height: 10vh;
     filter: drop-shadow(0 2px 10px rgba(0,0,0,0.5));
+}
+
+/* ==========================================================================
+   Novo Modo de Memórias com Bolhas Flutuantes
+   ========================================================================== */
+#message-bubbles-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.message-bubble {
+    position: absolute;
+    bottom: -150px;
+    width: 280px;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.95);
+    color: var(--text-color);
+    border-radius: var(--border-radius);
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.3);
+    font-size: 1.2rem;
+    opacity: 0;
+    transform: translateX(-50%);
+    animation-name: bubble-rise;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+}
+
+.message-bubble .recipient,
+.message-bubble .message,
+.message-bubble .sender,
+.message-bubble .timestamp {
+    margin: 0;
+    text-align: center;
+}
+.message-bubble .recipient {
+    font-family: 'Lilita One', cursive;
+    font-size: 1.5rem;
+    color: var(--primary-color);
+}
+.message-bubble .message {
+    font-size: 1.2rem;
+    margin: 10px 0;
+    font-weight: 500;
+}
+.message-bubble .sender {
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+.message-bubble .timestamp {
+    font-size: 0.9rem;
+    color: #777;
+}
+
+@keyframes bubble-rise {
+    0% {
+        transform: translate(-50%, 100vh) scale(0.8);
+        opacity: 0;
+    }
+    10% {
+        opacity: 1;
+    }
+    90% {
+        opacity: 1;
+    }
+    100% {
+        transform: translate(-50%, -150px) scale(1);
+        opacity: 0;
+    }
 }
 

--- a/public/display.html
+++ b/public/display.html
@@ -79,8 +79,9 @@
                 </div>
             </div>
             <div id="history-messages-container">
-                <!-- As mensagens que sobem aparecerão aqui -->
+                <!-- Colunas antigas ocultas -->
             </div>
+            <div id="message-bubbles-container" class="hidden"></div>
         </div>
     </div>
     

--- a/public/js/display.js
+++ b/public/js/display.js
@@ -81,6 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
         waitingScreen.classList.add('hidden');
         messageScreen.classList.add('hidden');
         historyPlaybackScreen.classList.add('hidden');
+        if (messageBubblesContainer) messageBubblesContainer.classList.add('hidden');
 
         // Para qualquer animação em andamento
         if (historyAnimationInterval) {
@@ -97,6 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
             stopIncentiveCycle();
         } else if (state === 'history') {
             historyPlaybackScreen.classList.remove('hidden');
+            if (messageBubblesContainer) messageBubblesContainer.classList.remove('hidden');
             stopIncentiveCycle();
         }
     };
@@ -399,11 +401,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const historyPlaybackScreen = document.getElementById('history-playback-screen');
     const historyContainer = document.getElementById('history-messages-container');
+    const messageBubblesContainer = document.getElementById('message-bubbles-container');
     let historyAnimationInterval = null;
 
     const renderHistoryScreen = (history) => {
         setScreenState('history');
         historyContainer.innerHTML = '';
+        if (messageBubblesContainer) {
+            messageBubblesContainer.innerHTML = '';
+        }
         if (!history || history.length === 0) return;
 
         // Gera o QR Code para o painel superior
@@ -418,34 +424,33 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
 
-        const numColumns = Math.min(Math.floor(window.innerWidth / 500), 4);
-        const columns = [];
-        for (let i = 0; i < numColumns; i++) {
-            const colDiv = document.createElement('div');
-            colDiv.className = 'history-column';
-            columns.push(colDiv);
-            historyContainer.appendChild(colDiv);
-        }
-
-        // Distribui as mensagens nas colunas
+        // Cria bolhas flutuantes para cada mensagem
         history.forEach((msg, index) => {
-            const colIndex = index % numColumns;
-            columns[colIndex].appendChild(createHistoryCard(msg));
+            const bubble = createHistoryBubble(msg, index);
+            messageBubblesContainer.appendChild(bubble);
         });
     };
 
-    const createHistoryCard = (msg) => {
-        const card = document.createElement('div');
-        card.className = 'history-message-card';
-        
+    const createHistoryBubble = (msg, index) => {
+        const bubble = document.createElement('div');
+        bubble.className = 'message-bubble';
+
         const time = new Date(msg.timestamp).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
-        
-        card.innerHTML = `
+
+        bubble.innerHTML = `
             <p class="recipient">Para: <strong>${msg.recipient}</strong></p>
             <p class="message">"${msg.message}"</p>
             <p class="sender">De: <strong>${msg.sender}</strong></p>
             <p class="timestamp">${time}</p>
         `;
-        return card;
+
+        const left = 10 + Math.random() * 80; // entre 10% e 90%
+        const delay = index * 2; // espaçamento
+        const duration = 20 + Math.random() * 10; // 20-30s
+        bubble.style.left = `${left}%`;
+        bubble.style.animationDuration = `${duration}s`;
+        bubble.style.animationDelay = `${delay}s`;
+
+        return bubble;
     };
 }); 


### PR DESCRIPTION
## Summary
- add floating bubble animation for memory mode
- include bubble container in display layout
- style floating bubbles with animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b7b552f04832ab5113d5feb05661a