### PR TITLE
Add concurrency test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "jest": "^29.7.0",
+        "socket.io-client": "^4.8.1",
         "supertest": "^6.3.4"
       }
     },
@@ -1975,6 +1976,45 @@
       "engines": {
         "node": ">=10.2.0"
       }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
@@ -4460,6 +4500,47 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -5010,6 +5091,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "cookie-session": "^2.1.0",
     "express": "^4.19.2",
     "express-useragent": "^1.0.15",
-    "socket.io": "^4.7.5",
-    "helmet": "^7.0.0"
+    "helmet": "^7.0.0",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "socket.io-client": "^4.8.1",
     "supertest": "^6.3.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -495,7 +495,7 @@ io.on('connection', (socket) => {
     };
     
     // Timeout para detectar páginas que não se registram em 5 segundos
-    setTimeout(() => {
+    const detectTimeout = setTimeout(() => {
         if (connectedClients[socket.id] && connectedClients[socket.id].page === 'Conectando...') {
             // Tenta detectar a página pela URL do referer
             const referer = socket.handshake.headers.referer;
@@ -512,6 +512,7 @@ io.on('connection', (socket) => {
             updateClientsAdmin();
         }
     }, 5000);
+    detectTimeout.unref();
     
     // Atualiza o pico de clientes conectados
     const currentClientCount = Object.keys(connectedClients).length;
@@ -772,4 +773,9 @@ if (require.main === module) {
     });
 }
 
-module.exports = { app, server };
+const shutdown = () => {
+    clearTimeout(idleLoopTimeout);
+    io.close();
+};
+
+module.exports = { app, server, io, shutdown };

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const ioClient = require('socket.io-client');
+
+process.env.ADMIN_PASSWORD = 'testpass';
+process.env.SESSION_SECRET = 'testsecret';
+const { app, server, io, shutdown } = require('../server');
+
+describe('Concurrent clients', () => {
+  let httpServer;
+  let port;
+
+  beforeAll(done => {
+    httpServer = server.listen(0, () => {
+      port = httpServer.address().port;
+      done();
+    });
+  });
+
+  afterAll(done => {
+    shutdown();
+    httpServer.close(done);
+  });
+
+  test('handles 50 clients sending messages', async () => {
+    const clientCount = 50;
+    const sockets = [];
+    const sendPromises = [];
+
+    for (let i = 0; i < clientCount; i++) {
+      const socket = ioClient(`http://localhost:${port}`, { transports: ['websocket'], forceNew: true, reconnection: false });
+      sockets.push(socket);
+      sendPromises.push(new Promise(resolve => {
+        socket.on('connect', () => {
+          socket.emit('newMessage', {
+            recipient: `Dest ${i}`,
+            sender: `Sender ${i}`,
+            message: `Msg ${i}`,
+            id: i
+          });
+        });
+        socket.on('queueUpdate', () => {
+          resolve();
+        });
+      }));
+    }
+
+    await Promise.all(sendPromises);
+
+    // Aguarda o processamento completo no servidor
+    await new Promise(r => setTimeout(r, 500));
+
+    sockets.forEach(s => s.close());
+
+    const agent = request.agent(app);
+    await agent
+      .post('/login')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(`password=${process.env.ADMIN_PASSWORD}`);
+
+    const res = await agent.get('/api/history');
+    expect(res.status).toBe(200);
+    expect(res.body.log.length).toBeGreaterThanOrEqual(clientCount);
+  }, 15000);
+});


### PR DESCRIPTION
## Summary
- add `socket.io-client` as dev dependency
- expose `io` shutdown helper in server
- avoid timer leaks with `unref` on detection timeout
- test concurrent client messages with 50 simultaneous connections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b9ade4c08832a9597f59be24005a2