### PR TITLE
Simplifica modo memórias

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -801,15 +801,7 @@ body.display-page {
     color: white;
     overflow: hidden;
     position: relative;
-    background: linear-gradient(45deg, #667eea, #764ba2, #f093fb, #f5576c);
-    background-size: 400% 400%;
-    animation: gradientShift 15s ease infinite;
-}
-
-@keyframes gradientShift {
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
+    background: transparent;
 }
 
 #history-top-panel {
@@ -936,13 +928,13 @@ body.display-page {
 
 .history-message-card .recipient {
     font-family: 'Lilita One', cursive;
-    font-size: 1.9rem;
+    font-size: 2.1rem;
     color: var(--primary-color);
     margin: 0;
 }
 
 .history-message-card .message {
-    font-size: 1.5rem;
+    font-size: 1.8rem;
     margin: 12px 0;
     font-weight: 500;
     line-height: 1.4;
@@ -957,7 +949,7 @@ body.display-page {
 }
 
 .history-message-card .sender {
-    font-size: 1.4rem;
+    font-size: 1.6rem;
     font-weight: 500;
     margin: 0;
 }

--- a/public/js/display.js
+++ b/public/js/display.js
@@ -430,8 +430,11 @@ document.addEventListener('DOMContentLoaded', () => {
             historyContainer.appendChild(colDiv);
         }
 
+        // Embaralha as mensagens para exibição randômica
+        const shuffled = [...history].sort(() => Math.random() - 0.5);
+
         // Distribui as mensagens nas colunas
-        history.forEach((msg, index) => {
+        shuffled.forEach((msg, index) => {
             const colIndex = index % numColumns;
             columns[colIndex].appendChild(createHistoryCard(msg));
         });
@@ -446,25 +449,9 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const time = new Date(msg.timestamp).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
         
-        // Cores de fundo aleatórias divertidas
-        const colors = [
-            'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-            'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
-            'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
-            'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
-            'linear-gradient(135deg, #fa709a 0%, #fee140 100%)',
-            'linear-gradient(135deg, #30cfd0 0%, #330867 100%)',
-            'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)',
-            'linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%)'
-        ];
-        const randomColor = colors[Math.floor(Math.random() * colors.length)];
-        card.style.background = randomColor;
-        
-        // Adiciona borda colorida aleatória
-        const borderColors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#f7dc6f', '#bb8fce', '#85c1e2', '#f8b500', '#ff6348'];
-        card.style.borderLeftColor = borderColors[Math.floor(Math.random() * borderColors.length)];
-        card.style.borderLeftWidth = '8px';
-        card.style.borderLeftStyle = 'solid';
+        // Estilo simples para foco nas mensagens
+        card.style.background = '#ffffff';
+        card.style.borderLeft = '4px solid var(--primary-color)';
         
         card.innerHTML = `
             <div class="message-header">
@@ -477,10 +464,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 <p class="timestamp">${time}</p>
             </div>
         `;
-        
-        // Adiciona rotação leve aleatória
-        const rotation = (Math.random() - 0.5) * 6; // -3 a +3 graus
-        card.style.transform = `rotate(${rotation}deg)`;
         
         return card;
     };
@@ -527,26 +510,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Nova função para iniciar animações divertidas
     const startHistoryAnimations = () => {
         const cards = document.querySelectorAll('.history-message-card');
-        
+
         cards.forEach((card, index) => {
-            // Adiciona delay aleatório para cada card
-            const delay = Math.random() * 2;
+            const delay = Math.random() * 1;
             card.style.animationDelay = `${delay}s`;
-            
-            // Adiciona classe de animação aleatória
-            const animations = ['bounce-in', 'slide-in', 'fade-in', 'rotate-in', 'zoom-in'];
-            const randomAnimation = animations[Math.floor(Math.random() * animations.length)];
-            card.classList.add(randomAnimation);
-            
-            // Adiciona emojis decorativos aleatórios
-            if (Math.random() > 0.5) {
-                const emojis = ['💖', '✨', '🌟', '💫', '🎉', '🎁', '💝', '🎊', '👍🏻', '💕', '🍀', '😊'];
-                const emoji = emojis[Math.floor(Math.random() * emojis.length)];
-                const emojiSpan = document.createElement('span');
-                emojiSpan.className = 'floating-emoji';
-                emojiSpan.textContent = emoji;
-                card.appendChild(emojiSpan);
-            }
+            card.classList.add('fade-in');
         });
     };
 }); 


### PR DESCRIPTION
## Summary
- remove colorful gradients and rotations in memory mode
- randomize messages order
- use white card background with default border
- enlarge fonts for better readability
- use display background instead of animated gradient

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c1bb953a0832abaae317c83eb350b